### PR TITLE
Update repository to pull from new mssql-server-2017 rpms, refs issue #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ LABEL name="microsoft/mssql-server-linux" \
 
 RUN yum install -y sudo
 # Install latest mssql-server package
-RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms,packages-microsoft-com-mssql-server,packages-microsoft-com-prod && \
-    curl https://packages.microsoft.com/config/rhel/7/mssql-server.repo > /etc/yum.repos.d/mssql-server.repo && \
+RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms,packages-microsoft-com-mssql-server-2017,packages-microsoft-com-prod && \
+    curl https://packages.microsoft.com/config/rhel/7/mssql-server-2017.repo > /etc/yum.repos.d/mssql-server.repo && \
     curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/msprod.repo && \
     yum remove unixODBC && \
     ACCEPT_EULA=Y yum install --disablerepo "*" --enablerepo ${REPOLIST} --setopt=tsflags=nodocs -y mssql-server  msodbcsql  mssql-tools && \


### PR DESCRIPTION
This fixes up the repo location to the new 2017 repository for mssql.

Without this fix I'm getting the error

Error: The evaluation period has expired.