### PR TITLE
Speed up initial image build by restricting repository selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL name="microsoft/mssql-server-linux" \
       io.k8s.description="MS SQL Server is ....." \
       io.k8s.display-name="MS SQL Server Developer Edition"
 
-RUN yum install -y sudo
+RUN yum install --disablerepo "*" --enablerepo rhel-7-server-rpms,rhel-7-server-optional-rpms -y sudo
 # Install latest mssql-server package
 RUN REPOLIST=rhel-7-server-rpms,rhel-7-server-optional-rpms,packages-microsoft-com-mssql-server,packages-microsoft-com-prod && \
     curl https://packages.microsoft.com/config/rhel/7/mssql-server.repo > /etc/yum.repos.d/mssql-server.repo && \


### PR DESCRIPTION
Restrict the repository list used to install sudo.

The base Red Hat image can have a large number of repositories enabled.